### PR TITLE
ci: make deploy workflow robust - drop fragile ssh-keyscan

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,18 +18,28 @@ jobs:
   deploy:
     name: SSH deploy (aergas + spk2 + spk3)
     runs-on: ubuntu-latest
+    env:
+      SSH_HOST: ${{ secrets.SSH_HOST }}
+      SSH_USER: ${{ secrets.SSH_USER }}
+      SSH_PORT: ${{ secrets.SSH_PORT }}
     steps:
       - name: Setup SSH key
         run: |
+          set -e
           mkdir -p ~/.ssh
-          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/deploy_key
+          chmod 700 ~/.ssh
+          printf '%s\n' "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -p "${{ secrets.SSH_PORT }}" -H "${{ secrets.SSH_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null
+          # Default port 22 kalau secret SSH_PORT kosong
+          echo "PORT=${SSH_PORT:-22}" >> "$GITHUB_ENV"
 
       - name: Deploy all sites
         run: |
+          set -e
           ssh -i ~/.ssh/deploy_key \
-              -p "${{ secrets.SSH_PORT }}" \
+              -p "${PORT}" \
               -o BatchMode=yes \
-              "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}" \
+              -o StrictHostKeyChecking=accept-new \
+              -o ConnectTimeout=20 \
+              "${SSH_USER}@${SSH_HOST}" \
               'bash /home/deploy/deploy-all.sh'


### PR DESCRIPTION
- Remove ssh-keyscan (non-zero exit killed step under bash -e)
- Use StrictHostKeyChecking=accept-new instead
- Default SSH_PORT to 22, add ConnectTimeout